### PR TITLE
Add anaconda channel requirement to setup notes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Installation with conda
 
 Create an environment:
 
-  conda create -n adel -c openalea openalea.plantgl boost=1.66
+  conda create -n adel -c anaconda -c openalea openalea.plantgl boost=1.66
 
 Activate the environment:
 


### PR DESCRIPTION
The conda command to create an environment fails when the `anaconda` channel is not included